### PR TITLE
feat: use replicas key if scale is not enabled

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - name: DAI
     email: dai@tamedia.ch
 type: application
-version: 1.0.0
+version: 1.1.0

--- a/charts/webapp/README.md
+++ b/charts/webapp/README.md
@@ -1,6 +1,6 @@
 # webapp
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic kubernetes application
 
@@ -90,6 +90,7 @@ ingress:
 | probe.startup | string | `nil` |  |
 | probe.startupHttpHeaders | string | `nil` |  |
 | probe.startupTimeoutSeconds | int | `1` |  |
+| replicas | int | `1` |  |
 | resources | object | `{}` |  |
 | scale.cpuThresholdPercentage | int | `100` |  |
 | scale.enabled | bool | `true` |  |

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -19,8 +19,8 @@ metadata:
     tags.datadoghq.com/version: {{ .Values.metadata.labels.datadog.version }}
     {{- end }}
 spec:
-  {{- if not .Values.scale.enabled }} # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling
-  replicas: {{ .Values.scale.minReplicas }}
+  {{- if and (not .Values.scale.enabled) (.Values.replicas) }} # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling
+  replicas: {{ .Values.replicas }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/webapp/templates/pod_disruption_budget.yaml
+++ b/charts/webapp/templates/pod_disruption_budget.yaml
@@ -1,6 +1,6 @@
-# by setting minReplica = 1 the PDB won't be deployed.
-# if you want HA then minReplica must be > 1.
-{{- if gt (int .Values.scale.minReplicas) 1 }}
+# by setting scale.minReplica = 1 or replicas = 1 the PDB won't be created.
+# if you want HA then scale.minReplica must be > 1 or replicas > 1
+{{- if (or (and .Values.scale.enabled (gt (int .Values.scale.minReplicas) 1)) (gt (int .Values.replicas) 1)) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -1,3 +1,6 @@
+# Set replicas if scaling is not enabled
+replicas: 1
+
 # App specific configs
 scale:
   enabled: true


### PR DESCRIPTION
use replicas value for deployments that do not enable scaling