### PR TITLE
feat(webapp): add gRPC probe support

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - name: DAI
     email: dai@tamedia.ch
 type: application
-version: 1.13.1
+version: 1.14.0

--- a/charts/webapp/README.md
+++ b/charts/webapp/README.md
@@ -1,6 +1,6 @@
 # webapp
 
-![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic kubernetes application
 
@@ -27,6 +27,21 @@ resource "helm_release" "app" {
 ## Upgrading
 
 This section lists major and breaking changes of each Helm Chart version.
+
+<details>
+<summary>1.14.0</summary>
+
+- Add support for gRPC liveness, readiness and startup probes. When `probe.grpc.port` is set, all three probes use a gRPC health check instead of `httpGet` (mutually exclusive with HTTP path probes).
+
+```yaml
+probe:
+  grpc:
+    port: 50051
+  livenessInitialDelaySeconds: 10
+  readinessInitialDelaySeconds: 5
+```
+
+</details>
 
 <details>
 <summary>1.11.0</summary>
@@ -131,6 +146,7 @@ ingress:
 | metadata.podAnnotations | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| probe.grpc | object | `{}` | gRPC probe port. When set, liveness, readiness and startup probes use a gRPC health check instead of httpGet (mutually exclusive with the HTTP path probes). |
 | probe.liveness | string | `"/"` |  |
 | probe.livenessInitialDelaySeconds | int | `0` |  |
 | probe.livenessPeriodSeconds | int | `10` |  |

--- a/charts/webapp/README.md.gotmpl
+++ b/charts/webapp/README.md.gotmpl
@@ -30,6 +30,21 @@ resource "helm_release" "app" {
 This section lists major and breaking changes of each Helm Chart version.
 
 <details>
+<summary>1.14.0</summary>
+
+- Add support for gRPC liveness, readiness and startup probes. When `probe.grpc.port` is set, all three probes use a gRPC health check instead of `httpGet` (mutually exclusive with HTTP path probes).
+
+```yaml
+probe:
+  grpc:
+    port: 50051
+  livenessInitialDelaySeconds: 10
+  readinessInitialDelaySeconds: 5
+```
+
+</details>
+
+<details>
 <summary>1.11.0</summary>
 
 - Updated API version for ExternalSecret to v1

--- a/charts/webapp/ci/grpc-probe-values.yaml
+++ b/charts/webapp/ci/grpc-probe-values.yaml
@@ -1,0 +1,5 @@
+probe:
+  grpc:
+    port: 50051
+  livenessInitialDelaySeconds: 10
+  readinessInitialDelaySeconds: 5

--- a/charts/webapp/ci/grpc-probe-values.yaml
+++ b/charts/webapp/ci/grpc-probe-values.yaml
@@ -1,5 +1,0 @@
-probe:
-  grpc:
-    port: 50051
-  livenessInitialDelaySeconds: 10
-  readinessInitialDelaySeconds: 5

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -143,27 +143,41 @@ spec:
             - name: {{ .Values.service.portName }}
               containerPort:  {{ default .Values.service.targetPort .Values.port }}
               protocol: TCP
-          {{- if .Values.probe.liveness }}
+          {{- if or .Values.probe.grpc .Values.probe.liveness }}
           livenessProbe:
+            {{- if .Values.probe.grpc }}
+            grpc:
+              port: {{ .Values.probe.grpc.port }}
+            {{- else }}
             httpGet:
               path: {{ .Values.probe.liveness | quote }}
               port: http
+            {{- end }}
             initialDelaySeconds: {{ .Values.probe.livenessInitialDelaySeconds }}
             periodSeconds: {{ .Values.probe.livenessPeriodSeconds }}
             timeoutSeconds: {{ .Values.probe.livenessTimeoutSeconds }}
           {{- end }}
-          {{- if .Values.probe.readiness }}
+          {{- if or .Values.probe.grpc .Values.probe.readiness }}
           readinessProbe:
+            {{- if .Values.probe.grpc }}
+            grpc:
+              port: {{ .Values.probe.grpc.port }}
+            {{- else }}
             httpGet:
               path: {{ .Values.probe.readiness | quote }}
               port: http
+            {{- end }}
             initialDelaySeconds: {{ .Values.probe.readinessInitialDelaySeconds }}
             periodSeconds: {{ .Values.probe.readinessPeriodSeconds }}
             timeoutSeconds: {{ .Values.probe.readinessTimeoutSeconds }}
             failureThreshold: {{ .Values.probe.readinessFailureThreshold }}
           {{- end }}
-          {{- if .Values.probe.liveness }}
+          {{- if or .Values.probe.grpc .Values.probe.liveness }}
           startupProbe:
+            {{- if .Values.probe.grpc }}
+            grpc:
+              port: {{ .Values.probe.grpc.port }}
+            {{- else }}
             httpGet:
               path: {{ coalesce .Values.probe.startup .Values.probe.liveness | quote }}
               port: http
@@ -171,6 +185,7 @@ spec:
               httpHeaders:
                 {{ .Values.probe.startupHttpHeaders | toYaml | nindent 16 }}
               {{- end }}
+            {{- end }}
             failureThreshold: 40
             periodSeconds: 3
             timeoutSeconds: {{ .Values.probe.startupTimeoutSeconds }}

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -51,6 +51,9 @@ probe:
   startup:
   startupTimeoutSeconds: 1
   startupHttpHeaders:
+  # -- gRPC probe port. When set, liveness, readiness and startup probes use a gRPC health check instead of httpGet (mutually exclusive with the HTTP path probes).
+  grpc: {}
+  #   port: 50051
 
 service:
   # Enable the service


### PR DESCRIPTION
## Summary

Adds gRPC health check support to the `webapp` Helm chart. When `probe.grpc.port` is set, all three probes (liveness, readiness, and startup) switch from `httpGet` to `grpc` health checks. The two probe types are mutually exclusive — configuring `probe.grpc` disables HTTP path probes.

## Changes

- **`values.yaml`**: Added `probe.grpc` field (default `{}`). Setting `probe.grpc.port` enables gRPC probes across all health checks.
- **`templates/deployment.yaml`**: Updated liveness, readiness, and startup probe templates to conditionally render `grpc` instead of `httpGet` when `probe.grpc` is configured.
- **`ci/grpc-probe-values.yaml`**: Added CI test values to validate the new gRPC probe path.
- **`Chart.yaml`**: Bumped chart version `1.13.1` → `1.14.0` (minor, new feature).
- **`README.md` / `README.md.gotmpl`**: Documented the new `probe.grpc` parameter.
